### PR TITLE
Fix pickle error

### DIFF
--- a/sync_batchnorm/comm.py
+++ b/sync_batchnorm/comm.py
@@ -75,6 +75,12 @@ class SyncMaster(object):
         self._registry = collections.OrderedDict()
         self._activated = False
 
+    def __getstate__(self):
+        return {'master_callback': self._master_callback}
+
+    def __setstate__(self, state):
+        self.__init__(state['master_callback'])
+
     def register_slave(self, identifier):
         """
         Register an slave device.


### PR DESCRIPTION
I found a bug about pickling the network that has used `_SynchronizedBatchNorm` module. Because Python (at least in my environment) cannot directly pickle `_thread.lock`, and the `_thread.lock` is invoked in a `SyncMaster` instance inside `_SynchronizedBatchNorm`, it would throw
```
TypeError: can't pickle _thread.lock objects
```
when I tried to use `copy.deepcopy()` or `torch.save()`. It is really inconvenient for saving best trained network.

There are many possible solutions. Because the `SyncMaster` instance is useless after training, the simplest way is just not to really save the `SyncMaster` instance during pickling, and reinitialize it for unpickling.

Environment:
```
CentOS 6.9 (x86-64)
Python 3.6.6 (Anaconda channel)
PyTorch 0.4.1 (Anaconda channel)
```
