### PR TITLE
New numeric test

### DIFF
--- a/sync_batchnorm/batchnorm_reimpl.py
+++ b/sync_batchnorm/batchnorm_reimpl.py
@@ -70,5 +70,5 @@ class BatchNorm2dReimpl(nn.Module):
                 (input_ - mean.unsqueeze(1)) * inv_std.unsqueeze(1) *
                 self.weight.unsqueeze(1) + self.bias.unsqueeze(1))
 
-        return output.permute(1, 0).contiguous().view(batchsize, channels, height, width)
+        return output.view(channels, batchsize, height, width).permute(1, 0, 2, 3).contiguous()
 

--- a/sync_batchnorm/batchnorm_reimpl.py
+++ b/sync_batchnorm/batchnorm_reimpl.py
@@ -53,21 +53,21 @@ class BatchNorm2dReimpl(nn.Module):
         sum_of_square = input_.pow(2).sum(1)
         mean = sum_ / numel
         sumvar = sum_of_square - sum_ * mean
-        unbias_var = sumvar / (numel - 1)
-        bias_var = sumvar / numel
-        std = bias_var.clamp(self.eps) ** 0.5
 
         self.running_mean = (
                 (1 - self.momentum) * self.running_mean
                 + self.momentum * mean.detach()
         )
+        unbias_var = sumvar / (numel - 1)
         self.running_var = (
                 (1 - self.momentum) * self.running_var
                 + self.momentum * unbias_var.detach()
         )
 
+        bias_var = sumvar / numel
+        inv_std = 1 / (bias_var + self.eps).pow(0.5)
         output = (
-                (input_ - mean.unsqueeze(1)) / std.unsqueeze(1) *
+                (input_ - mean.unsqueeze(1)) * inv_std.unsqueeze(1) *
                 self.weight.unsqueeze(1) + self.bias.unsqueeze(1))
 
         return output.permute(1, 0).contiguous().view(batchsize, channels, height, width)

--- a/sync_batchnorm/unittest.py
+++ b/sync_batchnorm/unittest.py
@@ -13,7 +13,7 @@ import torch
 
 
 class TorchTestCase(unittest.TestCase):
-    def assertTensorClose(self, x, y, atol=1e-3, rtol=1e-3):
+    def assertTensorClose(self, x, y):
         adiff = float((x - y).abs().max())
         if (y == 0).all():
             rdiff = 'NaN'
@@ -25,5 +25,5 @@ class TorchTestCase(unittest.TestCase):
             'adiff={}\n'
             'rdiff={}\n'
         ).format(adiff, rdiff)
-        self.assertTrue(torch.allclose(x, y, atol=atol, rtol=rtol), message)
+        self.assertTrue(torch.allclose(x, y), message)
 

--- a/tests/test_numeric_batchnorm_v2.py
+++ b/tests/test_numeric_batchnorm_v2.py
@@ -53,6 +53,8 @@ class NumericTestCasev2(TorchTestCase):
         self.assertTensorClose(input1.grad, input2.grad)
         self.assertTensorClose(batchnorm1.weight.grad, batchnorm2.weight.grad)
         self.assertTensorClose(batchnorm1.bias.grad, batchnorm2.bias.grad)
+        self.assertTensorClose(batchnorm1.running_mean, batchnorm2.running_mean)
+        self.assertTensorClose(batchnorm2.running_mean, batchnorm2.running_mean)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I rewrite the code while referencing `pytorch/aten/src/THNN/generic/BatchNormalization.c`

But it still can not pass two tests:

```
        self.assertTensorClose(input1.grad, input2.grad)
        self.assertTensorClose(batchnorm1.weight.grad, batchnorm2.weight.grad)
```